### PR TITLE
SHOR-4: Add missing screens for Mosaico pages

### DIFF
--- a/tests/backstop_data/backstop.tpl.json
+++ b/tests/backstop_data/backstop.tpl.json
@@ -14,10 +14,31 @@
     "html_report": "html_report",
     "ci_report": "ci_report"
   },
-  "scenarios": [{
-    "label": "Dashboard - test",
-    "url": "{url}/civicrm/a/#/mosaico-template"
-  }],
+  "scenarios": [
+    {
+      "label": "Mosaico - Main Page",
+      "url": "{url}/civicrm/a/#/mosaico-template",
+      "onReadyScript": "mosaico/main-page.js"
+    },
+    {
+      "label": "Mosaico - Main Page - hover state",
+      "url": "{url}/civicrm/a/#/mosaico-template",
+      "onReadyScript": "mosaico/main-page-hover-state.js"
+    },
+    {
+      "label": "Mosaico - Main Page - editor screens",
+      "url": "{url}/civicrm/a/#/mosaico-template",
+      "onReadyScript": "mosaico/editor.js"
+    },
+    {
+      "label": "Mosaico - Migrate",
+      "url": "{url}/civicrm/admin/mosaico/migrate"
+    },
+    {
+      "label": "Mosaico - Settings",
+      "url": "{url}/civicrm/admin/mosaico"
+    }       
+  ],
   "report": ["CLI", "browser"],
   "engine": "puppeteer",
   "engineOptions": {

--- a/tests/backstop_data/engine_scripts/puppet/mosaico/editor.js
+++ b/tests/backstop_data/engine_scripts/puppet/mosaico/editor.js
@@ -1,0 +1,7 @@
+'use strict';
+
+module.exports = async (engine, scenario, viewport) => {
+  await require('./main-page-hover-state.js')(engine, scenario, viewport);
+  await engine.click('.crm-mosaico-page > div:last-child .thumbnail a[title="Edit"]');
+  await engine.waitFor('.status-start', { hidden: true });
+};

--- a/tests/backstop_data/engine_scripts/puppet/mosaico/main-page-hover-state.js
+++ b/tests/backstop_data/engine_scripts/puppet/mosaico/main-page-hover-state.js
@@ -1,0 +1,6 @@
+'use strict';
+
+module.exports = async (engine, scenario, viewport) => {
+  await require('./main-page.js')(engine, scenario, viewport);
+  await engine.hover('.crm-mosaico-page > div:last-child .thumbnail');
+};

--- a/tests/backstop_data/engine_scripts/puppet/mosaico/main-page.js
+++ b/tests/backstop_data/engine_scripts/puppet/mosaico/main-page.js
@@ -1,0 +1,16 @@
+'use strict';
+
+module.exports = async (engine, scenario, viewport) => {
+  await engine.waitFor('.crm-mosaico-page');
+  // wait for images to load
+  await engine.evaluate(async () => {
+    const selectors = Array.from(document.querySelectorAll('img'));
+    await Promise.all(selectors.map(img => {
+      if (img.complete) return;
+      return new Promise((resolve, reject) => {
+        img.addEventListener('load', resolve);
+        img.addEventListener('error', reject);
+      });
+    }));
+  });
+};

--- a/tests/backstop_data/engine_scripts/puppet/mosaico/main-page.js
+++ b/tests/backstop_data/engine_scripts/puppet/mosaico/main-page.js
@@ -6,7 +6,10 @@ module.exports = async (engine, scenario, viewport) => {
   await engine.evaluate(async () => {
     const selectors = Array.from(document.querySelectorAll('img'));
     await Promise.all(selectors.map(img => {
-      if (img.complete) return;
+      if (img.complete) {
+        return;
+      }
+
       return new Promise((resolve, reject) => {
         img.addEventListener('load', resolve);
         img.addEventListener('error', reject);


### PR DESCRIPTION
## Overview
PR contains screens for 
* Mosaico - Main Page
  ![backstop_mosaico_mosaico_-_main_page_0_document_0_desktop](https://user-images.githubusercontent.com/3340537/42569684-f959b8b0-852e-11e8-8e25-481940d9c4e7.png)
* Mosaico - Main Page - hover state
  ![backstop_mosaico_mosaico_-_main_page_-_hover_state_0_document_0_desktop](https://user-images.githubusercontent.com/3340537/42569682-f929790c-852e-11e8-877d-b8400d0ca7ce.png)
* Mosaico - Main Page - editor screens
  ![backstop_mosaico_mosaico_-_main_page_-_editor_screens_0_document_0_desktop](https://user-images.githubusercontent.com/3340537/42569681-f8f79c02-852e-11e8-8570-de9417e9de9d.png)
* Mosaico - Migrate Page
  ![backstop_mosaico_mosaico_-_migrate_0_document_0_desktop](https://user-images.githubusercontent.com/3340537/42569686-f98abc8a-852e-11e8-96e2-b6c1aa096e4d.png)
* Mosaico - Settings Page
  ![backstop_mosaico_mosaico_-_settings_0_document_0_desktop](https://user-images.githubusercontent.com/3340537/42569688-f9bd3548-852e-11e8-96b1-4d115e4a0672.png)

## Technical Details

* For ensuring that main page screenshot contains loaded image a small image loading code snippet is added for `main-page.js`
* To cover hover state of the configured templates `.crm-mosaico-page > div:last-child .thumbnail` selector is used as there is no specific class applied on the configured templates container div.