### PR TITLE
SHOR-4: Remove semistandard and lint-staged from node package dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,11 +37,9 @@
     "backstopjs": "^3.3.1",
     "clean": "^4.0.2",
     "fs": "0.0.1-security",
-    "lint-staged": "^6.1.0",
     "lodash": "^4.17.10",
     "path": "^0.12.7",
     "plugin-error": "^1.0.1",
-    "semistandard": "^12.0.0",
     "yargs": "^4.8.1"
   }
 }


### PR DESCRIPTION
## Overview
PR removes `semistandard` and `lint-staged` from node modules as we are not using linter in the pre commit or anywhere in the code.